### PR TITLE
Don't emit undefined when no file name provided

### DIFF
--- a/stylish.js
+++ b/stylish.js
@@ -41,7 +41,7 @@ export default {
   formatResults: function (results, filename, options) {
     const {messages} = results
     let output = []
-    let underlinedFilename
+    let underlinedFilename = ''
     const {absoluteFilePathsForFormatters} = (options || {})
 
     if (messages.length > 0) {
@@ -80,6 +80,9 @@ export default {
       })
     }
 
-    return `\n${underlinedFilename}\n${table(output)}`
+    if (underlinedFilename) {
+      return `\n${underlinedFilename}\n${table(output)}`
+    }
+    return `\n${table(output)}`
   }
 }

--- a/test.js
+++ b/test.js
@@ -48,4 +48,18 @@ describe('csslint-stylish', () => {
 
     assert(CSSLint.hasFormat('stylish'), 'csslint should be stylish')
   })
+
+  it('should not report undefined output lines when no filename provided', () => {
+
+    const res = CSSLint.verify('.class {\n  color: red\n}\n')
+
+    let report = reporter.startFormat() + reporter.formatResults(res, path.resolve('style.css')) + reporter.endFormat()
+
+    report = chalk.stripColor(report)
+
+    let matches = report.match(/^undefined$/gm)
+
+    assert(matches === null, 'report should not contains undefined text output')
+  })
+
 })


### PR DESCRIPTION
While it was not an flow/logic error, This got the undefined text out of the output.

It includes passing test for failing case.