### PR TITLE
To have better contrast, use yellow to color warning message.

### DIFF
--- a/stylish.js
+++ b/stylish.js
@@ -71,7 +71,7 @@ export default {
           formatted.push(chalk.gray(`char ${col}`));
         }
 
-        formatted.push(isWarning ? chalk.blue(message) : chalk.red(message));
+        formatted.push(isWarning ? chalk.yellow(message) : chalk.red(message));
 
         return formatted;
       });


### PR DESCRIPTION
The blue looks difficult to read on my Mac. Here is a screenshot. Would you feel like that yellow font could be more suitable for a black background?

![screen shot 2016-08-15 at 2 45 18 pm](https://cloud.githubusercontent.com/assets/6490166/17680794/efe153a8-62f6-11e6-84f2-72281cc0d751.png)
